### PR TITLE
feat: Add placeable backpack blocks with Shift + Right-click

### DIFF
--- a/src/main/java/com/shweit/expendablebackpacks/ExpendableBackpacks.java
+++ b/src/main/java/com/shweit/expendablebackpacks/ExpendableBackpacks.java
@@ -2,12 +2,14 @@ package com.shweit.expendablebackpacks;
 
 import com.shweit.expendablebackpacks.commands.BackpackCommand;
 import com.shweit.expendablebackpacks.items.BackpackItem;
+import com.shweit.expendablebackpacks.listeners.BackpackBlockListener;
 import com.shweit.expendablebackpacks.listeners.BackpackCraftingListener;
 import com.shweit.expendablebackpacks.listeners.BackpackInteractionListener;
 import com.shweit.expendablebackpacks.listeners.BackpackProtectionListener;
 import com.shweit.expendablebackpacks.listeners.BackpackSmithingListener;
 import com.shweit.expendablebackpacks.recipes.BackpackRecipes;
 import com.shweit.expendablebackpacks.storage.BackpackManager;
+import com.shweit.expendablebackpacks.util.BackpackBlockUtil;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -22,6 +24,9 @@ public class ExpendableBackpacks extends JavaPlugin {
     public void onEnable() {
         // Initialize BackpackItem factory
         BackpackItem.initialize(this);
+
+        // Initialize BackpackBlockUtil for block operations
+        BackpackBlockUtil.initialize(this);
 
         // Initialize BackpackManager (storage)
         backpackManager = new BackpackManager(this);
@@ -40,6 +45,8 @@ public class ExpendableBackpacks extends JavaPlugin {
             new BackpackInteractionListener(backpackManager), this);
         getServer().getPluginManager().registerEvents(
             new BackpackProtectionListener(), this);
+        getServer().getPluginManager().registerEvents(
+            new BackpackBlockListener(), this);
         getServer().getPluginManager().registerEvents(
             new com.shweit.expendablebackpacks.gui.BackpackGuideGUI(), this);
 

--- a/src/main/java/com/shweit/expendablebackpacks/listeners/BackpackBlockListener.java
+++ b/src/main/java/com/shweit/expendablebackpacks/listeners/BackpackBlockListener.java
@@ -1,0 +1,189 @@
+package com.shweit.expendablebackpacks.listeners;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
+import com.shweit.expendablebackpacks.items.BackpackItem;
+import com.shweit.expendablebackpacks.items.BackpackTier;
+import com.shweit.expendablebackpacks.util.BackpackBlockUtil;
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Skull;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockBurnEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Handles placement, breaking, and protection of backpack blocks.
+ */
+public class BackpackBlockListener implements Listener {
+
+    /**
+     * Handles placement of backpack items as blocks.
+     *
+     * @param event the block place event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        ItemStack item = event.getItemInHand();
+
+        // Check if placing a backpack
+        if (!BackpackItem.isBackpack(item)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        Block block = event.getBlockPlaced();
+
+        @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+        UUID backpackUUID = BackpackItem.getBackpackUUID(item);
+        BackpackTier tier = BackpackItem.getBackpackTier(item);
+
+        if (backpackUUID == null || tier == null) {
+            player.sendMessage("§cError: Invalid backpack data!");
+            event.setCancelled(true);
+            return;
+        }
+
+        // Ensure the block is a player head
+        if (block.getType() != Material.PLAYER_HEAD
+            && block.getType() != Material.PLAYER_WALL_HEAD) {
+            return;
+        }
+
+        // Set the skull texture and store backpack data
+        if (block.getState() instanceof Skull skull) {
+            // Set the texture using Paper's profile API
+            String textureValue = tier.getTextureValue();
+            if (textureValue != null && !textureValue.startsWith("PLACEHOLDER")) {
+                try {
+                    PlayerProfile profile = Bukkit.createProfile(backpackUUID);
+                    profile.getProperties().add(
+                        new ProfileProperty("textures", textureValue));
+                    skull.setPlayerProfile(profile);
+                } catch (Exception e) {
+                    player.sendMessage("§cError: Failed to set backpack texture!");
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            // Store UUID and tier in the block's PDC
+            if (!BackpackBlockUtil.setBlockData(block, backpackUUID, tier)) {
+                player.sendMessage("§cError: Failed to store backpack data!");
+                event.setCancelled(true);
+                return;
+            }
+
+            player.sendMessage("§7Backpack placed! §8(Right-click to open)");
+        }
+    }
+
+    /**
+     * Handles breaking of backpack blocks.
+     *
+     * @param event the block break event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Block block = event.getBlock();
+
+        // Check if breaking a backpack block
+        if (!BackpackBlockUtil.isBackpackBlock(block)) {
+            return;
+        }
+
+        @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+        UUID backpackUUID = BackpackBlockUtil.getBackpackUUIDFromBlock(block);
+        BackpackTier tier = BackpackBlockUtil.getBackpackTierFromBlock(block);
+
+        if (backpackUUID == null || tier == null) {
+            return;
+        }
+
+        // Cancel default drops
+        event.setDropItems(false);
+
+        // Create and drop the backpack item with preserved UUID
+        ItemStack backpackItem = BackpackItem.createBackpack(tier, backpackUUID);
+        Location dropLocation = block.getLocation().add(0.5, 0.5, 0.5);
+        block.getWorld().dropItemNaturally(dropLocation, backpackItem);
+    }
+
+    /**
+     * Protects backpack blocks from entity explosions (Creeper, TNT, etc.).
+     *
+     * @param event the entity explode event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onEntityExplode(EntityExplodeEvent event) {
+        List<Block> blocks = event.blockList();
+        blocks.removeIf(BackpackBlockUtil::isBackpackBlock);
+    }
+
+    /**
+     * Protects backpack blocks from block explosions (Bed, Respawn Anchor, etc.).
+     *
+     * @param event the block explode event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockExplode(BlockExplodeEvent event) {
+        List<Block> blocks = event.blockList();
+        blocks.removeIf(BackpackBlockUtil::isBackpackBlock);
+    }
+
+    /**
+     * Protects backpack blocks from burning.
+     *
+     * @param event the block burn event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onBlockBurn(BlockBurnEvent event) {
+        Block block = event.getBlock();
+        if (BackpackBlockUtil.isBackpackBlock(block)) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Protects backpack blocks from being pushed by pistons.
+     *
+     * @param event the block piston extend event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPistonExtend(BlockPistonExtendEvent event) {
+        for (Block block : event.getBlocks()) {
+            if (BackpackBlockUtil.isBackpackBlock(block)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Protects backpack blocks from being pulled by sticky pistons.
+     *
+     * @param event the block piston retract event
+     */
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPistonRetract(BlockPistonRetractEvent event) {
+        for (Block block : event.getBlocks()) {
+            if (BackpackBlockUtil.isBackpackBlock(block)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/com/shweit/expendablebackpacks/util/BackpackBlockUtil.java
+++ b/src/main/java/com/shweit/expendablebackpacks/util/BackpackBlockUtil.java
@@ -1,0 +1,133 @@
+package com.shweit.expendablebackpacks.util;
+
+import com.shweit.expendablebackpacks.items.BackpackTier;
+import java.util.UUID;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.block.Block;
+import org.bukkit.block.Skull;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Utility class for handling backpack blocks (placed backpacks).
+ */
+public class BackpackBlockUtil {
+
+    private static Plugin plugin;
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    private static NamespacedKey BACKPACK_UUID_KEY;
+    private static NamespacedKey BACKPACK_TIER_KEY;
+
+    /**
+     * Initialize the BackpackBlockUtil with plugin instance.
+     *
+     * @param pluginInstance the plugin instance.
+     */
+    @SuppressWarnings("EI_EXPOSE_STATIC_REP2")
+    public static void initialize(Plugin pluginInstance) {
+        plugin = pluginInstance;
+        BACKPACK_UUID_KEY = new NamespacedKey(plugin, "backpack_uuid");
+        BACKPACK_TIER_KEY = new NamespacedKey(plugin, "backpack_tier");
+    }
+
+    /**
+     * Check if a block is a placed backpack.
+     *
+     * @param block the block to check.
+     * @return true if the block is a backpack, false otherwise.
+     */
+    public static boolean isBackpackBlock(Block block) {
+        if (block == null || block.getType() != Material.PLAYER_HEAD
+            && block.getType() != Material.PLAYER_WALL_HEAD) {
+            return false;
+        }
+
+        if (!(block.getState() instanceof Skull skull)) {
+            return false;
+        }
+
+        PersistentDataContainer pdc = skull.getPersistentDataContainer();
+        return pdc.has(BACKPACK_UUID_KEY, PersistentDataType.STRING);
+    }
+
+    /**
+     * Get the UUID of a backpack block.
+     *
+     * @param block the backpack block.
+     * @return the UUID of the backpack, or null if not a backpack block.
+     */
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    public static UUID getBackpackUUIDFromBlock(Block block) {
+        if (!isBackpackBlock(block)) {
+            return null;
+        }
+
+        Skull skull = (Skull) block.getState();
+        PersistentDataContainer pdc = skull.getPersistentDataContainer();
+        String uuidString = pdc.get(BACKPACK_UUID_KEY, PersistentDataType.STRING);
+
+        if (uuidString == null) {
+            return null;
+        }
+
+        try {
+            return UUID.fromString(uuidString);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Get the tier of a backpack block.
+     *
+     * @param block the backpack block.
+     * @return the tier of the backpack, or null if not a backpack block.
+     */
+    public static BackpackTier getBackpackTierFromBlock(Block block) {
+        if (!isBackpackBlock(block)) {
+            return null;
+        }
+
+        Skull skull = (Skull) block.getState();
+        PersistentDataContainer pdc = skull.getPersistentDataContainer();
+        Integer level = pdc.get(BACKPACK_TIER_KEY, PersistentDataType.INTEGER);
+
+        if (level == null) {
+            return null;
+        }
+
+        return BackpackTier.fromLevel(level);
+    }
+
+    /**
+     * Set backpack data on a placed block.
+     *
+     * @param block the block to set data on.
+     * @param uuid the backpack UUID.
+     * @param tier the backpack tier.
+     * @return true if successful, false otherwise.
+     */
+    @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+    public static boolean setBlockData(Block block, UUID uuid, BackpackTier tier) {
+        if (block == null || uuid == null || tier == null) {
+            return false;
+        }
+
+        if (block.getType() != Material.PLAYER_HEAD
+            && block.getType() != Material.PLAYER_WALL_HEAD) {
+            return false;
+        }
+
+        if (!(block.getState() instanceof Skull skull)) {
+            return false;
+        }
+
+        PersistentDataContainer pdc = skull.getPersistentDataContainer();
+        pdc.set(BACKPACK_UUID_KEY, PersistentDataType.STRING, uuid.toString());
+        pdc.set(BACKPACK_TIER_KEY, PersistentDataType.INTEGER, tier.getLevel());
+
+        return skull.update();
+    }
+}


### PR DESCRIPTION
feat: Add placeable backpack blocks with Shift + Right-click

Players can now place backpacks as blocks and interact with them:
- Shift + Right-click to place backpack as Player Head block
- Right-click on placed backpack to open inventory
- Breaking block returns backpack item with preserved UUID
- UUID and tier persist through item → block → item lifecycle
- Full protection from explosions, pistons, fire, and lava
- Enderpack shared storage works across placed blocks

Technical changes:
- Add BackpackBlockUtil for block data operations
- Add BackpackBlockListener for placement and protection
- Update BackpackInteractionListener for sneak detection
- Initialize BackpackBlockUtil in main plugin class