### PR TITLE
feat: Add configurable starter backpack for new players

### DIFF
--- a/MOD_DESCRIPTION.md
+++ b/MOD_DESCRIPTION.md
@@ -1,0 +1,243 @@
+# Expendable Backpacks
+
+**A comprehensive backpack system featuring eight progressive tiers, upgradeable storage, placeable backpack blocks, and unique Enderpack shared inventory functionality.**
+
+***
+
+## ✨ Features
+
+*   **Eight Progressive Tiers** - From basic Dirt Backpack (9 slots) to premium Netherite Backpack (54 slots)
+*   **Placeable Backpacks** - Place backpacks as blocks in the world using Shift + Right-click
+*   **Enderpack System** - Unique shared storage across multiple Enderpacks using UUID-based identification
+*   **Starter Backpack Configuration** - Give new players a Leather Backpack on first join
+*   **Stackable Upgrades** - Upgrade your backpacks by surrounding them with materials while preserving all contents
+*   **Inception Protection** - Smart system prevents nesting backpacks within other backpacks
+*   **Interactive GUI Guide** - In-game visual guide showing all crafting recipes and upgrade paths
+*   **Custom Textures** - Beautiful player head textures for each tier with color-coded names
+*   **Persistent Storage** - All backpack contents automatically saved with UUID tracking
+*   **Enderpack Cloning** - Create multiple access points to the same shared inventory
+*   **Full Protection** - Placed backpacks are protected from explosions, pistons, fire, and lava
+*   **Performance Optimized** - Efficient inventory caching and asynchronous data saving
+*   **Tab Completion** - Full tab completion support for all commands and UUIDs
+
+***
+
+## 🎒 Backpack Tiers
+
+| Tier               |Storage           |Upgrade Material   |
+| ------------------ |----------------- |------------------ |
+| Dirt Backpack      |9 slots (1 row)   |Surround with Dirt |
+| Leather Backpack   |9 slots (1 row)   |Starting tier      |
+| Copper Backpack    |18 slots (2 rows) |8x Copper Ingot    |
+| Iron Backpack      |27 slots (3 rows) |8x Iron Ingot      |
+| Gold Backpack      |36 slots (4 rows) |8x Gold Ingot      |
+| Diamond Backpack   |45 slots (5 rows) |8x Diamond         |
+| Netherite Backpack |54 slots (6 rows) |Smithing Table     |
+| <strong>Enderpack</strong> |27 slots (3 rows) |<strong>Shared Storage</strong> |
+
+***
+
+## 📦 Placeable Backpacks
+
+Backpacks can now be placed in the world as decorative blocks that retain full functionality!
+
+### How It Works
+
+*   **Place**: Hold a backpack and **Shift + Right-click** on any surface
+*   **Open**: **Right-click** the placed backpack to access its inventory
+*   **Break**: Mine the block to retrieve your backpack with all contents intact
+*   **Protection**: Placed backpacks are fully protected from:
+    *   Explosions (Creeper, TNT, etc.)
+    *   Pistons (push/pull)
+    *   Fire and lava damage
+    *   Block explosions (Beds, Respawn Anchors)
+
+### Use Cases
+
+*   **Storage Rooms** - Create organized storage areas with visible backpack tiers
+*   **Base Decoration** - Display your collection of high-tier backpacks
+*   **Quick Access Points** - Place backpacks at strategic locations around your base
+*   **Team Storage** - Place shared Enderpacks in communal areas
+*   **Shops & Trade** - Create backpack displays in marketplace builds
+
+### Important Notes
+
+*   Placed backpacks retain their UUID - items stay exactly where they are
+*   Breaking and replacing a backpack doesn't affect its contents
+*   Enderpacks work the same when placed - all copies share the same inventory
+*   You can still open backpacks in your hand with a normal right-click
+
+***
+
+## 🌌 Enderpack - The Special One
+
+The Enderpack provides unique functionality not found in other tiers:
+
+*   **Shared Storage** - All Enderpacks with the same UUID access identical inventory
+*   **Cloneable** - Craft 1 Enderpack + 1 Ender Pearl = 2 Enderpacks with matching UUID
+*   **Multiple Access Points** - Keep one in your inventory, one at your base, share with teammates
+*   **Works When Placed** - Place Enderpacks as blocks and they still share the same inventory
+*   **Perfect for Teams** - Coordinate shared storage across multiple players
+*   **Cross-Location Access** - Access the same inventory from anywhere
+
+### Example Use Case
+
+1.  Craft an Enderpack
+2.  Clone it by combining with an Ender Pearl (yields 2 Enderpacks, same UUID)
+3.  Keep one in your inventory for on-the-go access
+4.  **Place one as a block at your base for easy access**
+5.  Give one to a teammate
+6.  All three access the same 27-slot shared storage - even the placed one!
+
+***
+
+## ⚙️ Configuration
+
+The plugin includes a configuration file at `plugins/ExpendableBackpacks/config.yml` for server customization.
+
+### Starter Backpack Feature
+
+Give new players a Leather Backpack automatically when they first join your server:
+
+```yaml
+# Give a Leather Backpack to players when they first join the server
+# Default: false
+give-backpack-on-first-join: false
+
+# Message sent to players when they receive their starter backpack
+# Use & for color codes (e.g., &a for green, &6 for gold)
+# Set to empty string ("") to disable the message
+starter-backpack-message: "&7Welcome! You've been given a &7Leather Backpack &7to get started. Right-click to open!"
+```
+
+**Features:**
+*   Only triggers for players joining for the first time
+*   Automatically adds backpack to inventory
+*   Drops at player location if inventory is full
+*   Customizable welcome message with color code support
+*   Disabled by default - enable it in your config
+
+***
+
+## 🚀 Installation & Compatibility
+
+1.  Download the latest plugin JAR file
+2.  Place it in your server's `/plugins/` directory
+3.  Restart your server or use a plugin loader
+4.  Use `/backpack` to access the in-game guide
+5.  Configure starter backpack in `plugins/ExpendableBackpacks/config.yml` (optional)
+
+### Requirements
+
+*   **Server Software:** Paper, Spigot, Purpur, or Folia
+*   **Minecraft Version:** 1.21 or higher
+*   **Java Version:** 21 or higher
+
+***
+
+## 🔧 Commands & Permissions
+
+### Commands
+
+All commands support the `/bp` alias for quick access.
+
+| Command                        |Description                 |Permission          |
+| ------------------------------ |--------------------------- |------------------- |
+| <code>/backpack</code>         |Open interactive guide GUI  |<code>backpack.use</code> |
+| <code>/backpack help</code>    |Display help information    |<code>backpack.use</code> |
+| <code>/backpack give &lt;player&gt; &lt;tier&gt;</code> |Give a backpack to a player |<code>backpack.give</code> |
+| <code>/backpack open &lt;uuid&gt;</code> |Open a backpack by UUID     |<code>backpack.openOthers</code> |
+| <code>/backpack clear &lt;uuid&gt;</code> |Clear backpack contents     |<code>backpack.clear</code> |
+| <code>/backpack clone &lt;uuid&gt;</code> |Create an Enderpack clone   |<code>backpack.clone</code> |
+
+### Permissions
+
+| Permission          |Description                                 |Default  |
+| ------------------- |------------------------------------------- |-------- |
+| <code>backpack.use</code> |Use backpack command and open own backpacks |Everyone |
+| <code>backpack.give</code> |Give backpacks to players                   |OP       |
+| <code>backpack.openOthers</code> |Open any backpack by UUID                   |OP       |
+| <code>backpack.clear</code> |Clear backpack contents                     |OP       |
+| <code>backpack.clone</code> |Clone Enderpacks                            |OP       |
+| <code>backpack.admin</code> |All admin permissions                       |OP       |
+
+***
+
+## 🔨 Crafting Recipes
+
+### Leather Backpack (Starting Point)
+
+```
+L S L
+L C L
+L L L
+```
+
+*   L = Leather, S = String, C = Chest
+
+### Enderpack (Special Recipe)
+
+```
+E P E
+P C P
+E I E
+```
+
+*   E = Ender Eye, P = Ender Pearl, C = Chest, I = Iron Block
+
+### Upgrades
+
+Surround your backpack with **8x upgrade material**:
+
+*   Leather → Copper: 8x Copper Ingot
+*   Copper → Iron: 8x Iron Ingot
+*   Iron → Gold: 8x Gold Ingot
+*   Gold → Diamond: 8x Diamond
+*   Diamond → Netherite: Smithing Table (Netherite Upgrade Template + Diamond Backpack + Netherite Ingot)
+
+**Note:** All upgrades preserve your items and UUID!
+
+***
+
+## 💾 Technical Details
+
+### Data Storage
+
+*   Backpacks stored in `plugins/ExpendableBackpacks/backpacks.yml`
+*   UUID-based identification for each backpack instance
+*   Placed backpacks store UUID in block PersistentDataContainer
+*   Automatic inventory serialization
+*   Data persists across server restarts
+
+### Performance
+
+*   Efficient inventory caching system
+*   Asynchronous data saving
+*   Optimized block interaction handling
+*   Optimized for large-scale servers
+*   Minimal server resource usage
+
+### Placed Backpack Technical Details
+
+*   Placed as Player Head blocks with custom textures
+*   UUID and tier data stored in block NBT (PersistentDataContainer)
+*   Same NamespacedKeys as items for consistency
+*   Full event handling for comprehensive protection
+
+***
+
+## 🆘 Support & Links
+
+*   **Issues & Bug Reports:** [GitHub Issues](https://github.com/shweit/expendable-backpacks/issues)
+*   **Source Code:** [GitHub Repository](https://github.com/shweit/expendable-backpacks)
+*   **Documentation:** [Full README](https://github.com/shweit/expendable-backpacks/blob/master/README.md)
+
+***
+
+## 📜 License
+
+This plugin is licensed under the MIT License. See the [LICENSE](https://github.com/shweit/expendable-backpacks/blob/master/LICENSE) file for details.
+
+***
+
+**Developed with care for the Minecraft server community.**

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 A comprehensive backpack plugin for Paper/Spigot servers featuring eight unique tiers, progressive upgrades, and shared storage capabilities through the Enderpack system.
 
-[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](https://github.com/shweit/expendable-backpacks)
-[![Minecraft](https://img.shields.io/badge/minecraft-1.21.1-green.svg)](https://www.minecraft.net/)
+[![Minecraft](https://img.shields.io/badge/minecraft-1.21.1+-green.svg)](https://www.minecraft.net/)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
 ---
@@ -11,11 +10,14 @@ A comprehensive backpack plugin for Paper/Spigot servers featuring eight unique 
 ## Features
 
 - **Eight Backpack Tiers** - Progressive storage from 9 to 54 slots (Dirt, Leather, Copper, Iron, Gold, Diamond, Netherite, Enderpack)
+- **Placeable Backpacks** - Place backpacks as blocks in the world using Shift + Right-click
 - **Automatic Inventory Persistence** - All backpack contents saved automatically with YAML-based storage
 - **Stackable Upgrades** - Upgrade backpacks by surrounding them with materials while preserving contents
 - **Enderpack System** - Shared storage across multiple Enderpacks using UUID-based identification
 - **Enderpack Cloning** - Create multiple access points to the same inventory
+- **Starter Backpack Configuration** - Give new players a Leather Backpack on first join
 - **Inception Protection** - Prevents nesting backpacks within other backpacks
+- **Full Protection** - Placed backpacks protected from explosions, pistons, fire, and lava
 - **Custom Textures** - Unique player head textures for each tier
 - **Interactive GUI** - In-game guide displaying all crafting recipes and upgrade paths
 - **UUID-Based Storage** - Each backpack instance tracked with unique identifiers
@@ -119,7 +121,7 @@ All commands can be abbreviated using `/bp` as an alias for `/backpack`.
 
 ## Installation
 
-1. Download the latest `ExpendableBackpacks-1.0.0.jar` from the [Releases](https://github.com/shweit/expendable-backpacks/releases) page
+1. Download the latest JAR file from the [Releases](https://github.com/shweit/expendable-backpacks/releases) page
 2. Place the JAR file in your server's `plugins/` directory
 3. Restart or reload your server
 4. Use `/backpack` to access the interactive guide
@@ -134,7 +136,13 @@ All commands can be abbreviated using `/bp` as an alias for `/backpack`.
 ## Usage
 
 ### Opening Backpacks
-Right-click any backpack item in your inventory to access its contents.
+- **In Hand**: Right-click any backpack item in your inventory to access its contents
+- **Placed Block**: Right-click a placed backpack block to open its inventory
+
+### Placing Backpacks
+- **Place**: Hold a backpack and **Shift + Right-click** on any surface to place it as a block
+- **Break**: Mine the placed backpack to retrieve it with all contents intact
+- **Protection**: Placed backpacks are immune to explosions, pistons, fire, and lava
 
 ### Viewing the Guide
 Execute `/backpack` to open an interactive GUI displaying:
@@ -144,10 +152,11 @@ Execute `/backpack` to open an interactive GUI displaying:
 - Enderpack functionality details
 
 ### Creating Your First Backpack
-1. Craft a Leather Backpack using Leather, String, and a Chest
+1. Craft a Leather Backpack using Leather, String, and a Chest (or receive one on first join if configured)
 2. Right-click the backpack item to open its inventory
 3. Store items as needed
-4. Upgrade to higher tiers by surrounding with appropriate materials
+4. Optionally place it in your base using Shift + Right-click
+5. Upgrade to higher tiers by surrounding with appropriate materials
 
 ---
 
@@ -155,16 +164,19 @@ Execute `/backpack` to open an interactive GUI displaying:
 
 The Enderpack provides unique shared storage functionality:
 
-- **Shared Storage**: All Enderpacks with identical UUIDs access the same inventory
+- **Shared Storage**: All Enderpacks with identical UUIDs access the same inventory (items and placed blocks)
 - **Cloneable**: Combine one Enderpack with one Ender Pearl to create two Enderpacks sharing the same UUID
 - **Multiple Access Points**: Distribute cloned Enderpacks across different locations or players
+- **Works When Placed**: Placed Enderpack blocks share the same inventory as their item counterparts
 - **UUID-Based Identification**: Each Enderpack group identified by unique identifier
 
 ### Implementation Example
 1. Craft an initial Enderpack
 2. Clone the Enderpack by crafting it with an Ender Pearl (yields 2 Enderpacks with matching UUID)
-3. Distribute copies to different locations (inventory, storage chest, other players)
-4. All instances with the same UUID access shared storage
+3. Keep one in your inventory for on-the-go access
+4. Place one as a block at your base using Shift + Right-click
+5. Give one to a teammate or store in a chest
+6. All instances with the same UUID access shared storage - even the placed block!
 
 ---
 
@@ -180,11 +192,27 @@ Backpack data is persisted in `plugins/ExpendableBackpacks/backpacks.yml`:
 
 ## Configuration
 
-The plugin operates with default settings without additional configuration. Future releases may include:
-- Configurable storage capacity per tier
-- Customizable crafting recipes
-- Texture customization options
-- Per-tier permission requirements
+The plugin's configuration file is located at `plugins/ExpendableBackpacks/config.yml`.
+
+### Available Options
+
+```yaml
+# Give a Leather Backpack to players when they first join the server
+# Default: false
+give-backpack-on-first-join: false
+
+# Message sent to players when they receive their starter backpack
+# Use & for color codes (e.g., &a for green, &6 for gold)
+# Set to empty string ("") to disable the message
+starter-backpack-message: "&7Welcome! You've been given a &7Leather Backpack &7to get started. Right-click to open!"
+```
+
+### Starter Backpack Feature
+Enable `give-backpack-on-first-join: true` to automatically give new players a Leather Backpack when they join for the first time. This feature:
+- Only triggers for players who have never joined before
+- Adds the backpack to the player's inventory
+- Drops the backpack at the player's location if inventory is full
+- Sends a customizable welcome message with color code support
 
 ---
 
@@ -196,10 +224,15 @@ Report bugs or submit feature requests through the [GitHub Issues](https://githu
 
 ## Changelog
 
-### Version 1.0.0 - Initial Release
+See [CHANGELOG.md](CHANGELOG.md) for detailed version history.
+
+### Latest Features
+- Placeable backpacks as blocks (Shift + Right-click)
+- Full protection for placed backpacks (explosions, pistons, fire, lava)
+- Configurable starter backpack for new players
 - Eight backpack tiers with progressive storage (9-54 slots)
 - Enderpack shared storage system
-- Enderpack cloning mechanism (1:1 ratio)
+- Enderpack cloning mechanism
 - Material-based upgrade system
 - Inception protection mechanism
 - Interactive GUI guide with recipe visualization

--- a/src/main/java/com/shweit/expendablebackpacks/ExpendableBackpacks.java
+++ b/src/main/java/com/shweit/expendablebackpacks/ExpendableBackpacks.java
@@ -7,6 +7,7 @@ import com.shweit.expendablebackpacks.listeners.BackpackCraftingListener;
 import com.shweit.expendablebackpacks.listeners.BackpackInteractionListener;
 import com.shweit.expendablebackpacks.listeners.BackpackProtectionListener;
 import com.shweit.expendablebackpacks.listeners.BackpackSmithingListener;
+import com.shweit.expendablebackpacks.listeners.PlayerJoinListener;
 import com.shweit.expendablebackpacks.recipes.BackpackRecipes;
 import com.shweit.expendablebackpacks.storage.BackpackManager;
 import com.shweit.expendablebackpacks.util.BackpackBlockUtil;
@@ -22,6 +23,9 @@ public class ExpendableBackpacks extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Load configuration
+        saveDefaultConfig();
+
         // Initialize BackpackItem factory
         BackpackItem.initialize(this);
 
@@ -48,6 +52,8 @@ public class ExpendableBackpacks extends JavaPlugin {
         getServer().getPluginManager().registerEvents(
             new BackpackBlockListener(), this);
         getServer().getPluginManager().registerEvents(
+            new PlayerJoinListener(this), this);
+        getServer().getPluginManager().registerEvents(
             new com.shweit.expendablebackpacks.gui.BackpackGuideGUI(), this);
 
         // Register commands
@@ -58,11 +64,8 @@ public class ExpendableBackpacks extends JavaPlugin {
         // Initialize bStats metrics
         new Metrics(this, 28070);
 
-        getLogger().info("╔════════════════════════════════╗");
-        getLogger().info("║ Expendable Backpacks enabled!  ║");
-        getLogger().info("║  8 Tiers • Stack Crafting      ║");
-        getLogger().info("║  Enderpack Support • Commands  ║");
-        getLogger().info("╚════════════════════════════════╝");
+        getLogger().info("Expendable Backpacks has been enabled!");
+        getLogger().info("Features: 8 Tiers, Placeable Blocks, Enderpack Support");
     }
 
     @Override
@@ -74,10 +77,7 @@ public class ExpendableBackpacks extends JavaPlugin {
             backpackManager.saveAllInventories();
         }
 
-        getLogger().info("╔════════════════════════════════╗");
-        getLogger().info("║ Expendable Backpacks disabled  ║");
-        getLogger().info("║  All data saved successfully   ║");
-        getLogger().info("╚════════════════════════════════╝");
+        getLogger().info("Expendable Backpacks has been disabled. All data saved successfully.");
     }
 
     /**

--- a/src/main/java/com/shweit/expendablebackpacks/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/shweit/expendablebackpacks/listeners/PlayerJoinListener.java
@@ -1,0 +1,63 @@
+package com.shweit.expendablebackpacks.listeners;
+
+import com.shweit.expendablebackpacks.items.BackpackItem;
+import com.shweit.expendablebackpacks.items.BackpackTier;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Handles giving starter backpacks to new players on first join.
+ */
+public class PlayerJoinListener implements Listener {
+
+    private final Plugin plugin;
+
+    /**
+     * Creates a new player join listener.
+     *
+     * @param plugin the plugin instance
+     */
+    @SuppressWarnings("EI_EXPOSE_REP2")
+    public PlayerJoinListener(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Handles player join events to give starter backpack to new players.
+     *
+     * @param event the player join event
+     */
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+
+        // Check if feature is enabled in config
+        if (!plugin.getConfig().getBoolean("give-backpack-on-first-join", false)) {
+            return;
+        }
+
+        // Check if this is the player's first time joining
+        if (player.hasPlayedBefore()) {
+            return;
+        }
+
+        // Create and give the Leather Backpack
+        ItemStack leatherBackpack = BackpackItem.createBackpack(BackpackTier.LEATHER);
+
+        // Try to add to inventory, if full drop at player location
+        if (!player.getInventory().addItem(leatherBackpack).isEmpty()) {
+            player.getWorld().dropItemNaturally(player.getLocation(), leatherBackpack);
+        }
+
+        // Send welcome message if configured
+        String message = plugin.getConfig().getString("starter-backpack-message", "");
+        if (message != null && !message.trim().isEmpty()) {
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,18 @@
+# ================================================================
+# Expendable Backpacks Configuration
+# A comprehensive backpack system with progressive tiers
+# ================================================================
+
+# ---------------------------
+# Starter Backpack Settings
+# ---------------------------
+
+# Give a Leather Backpack to players when they first join the server
+# Set to 'true' to enable, 'false' to disable
+# Default: false
+give-backpack-on-first-join: false
+
+# Message sent to players when they receive their starter backpack
+# Use & for color codes (e.g., &a for green, &6 for gold)
+# Set to empty string ("") to disable the message
+starter-backpack-message: "&7Welcome! You've been given a &7Leather Backpack &7to get started. Right-click to open!"


### PR DESCRIPTION
Players can now receive a Leather Backpack on first join:
- New config option: give-backpack-on-first-join (default: false)
- Customizable welcome message with color code support
- Only triggers for players who have never joined before
- Backpack drops at player location if inventory is full
- Simplified log messages (removed ASCII box formatting)
- Clean config.yml with simple formatting

Technical changes:
- Add config.yml with starter backpack settings
- Add PlayerJoinListener for first-join detection
- Update ExpendableBackpacks to load config on startup
- Simplify all log messages (enable/disable)